### PR TITLE
Add GitHub username validator script (py)

### DIFF
--- a/python/github_username_validator.py
+++ b/python/github_username_validator.py
@@ -1,0 +1,14 @@
+import re
+
+def is_valid_github_username(username):
+    # GitHub username rules:
+    # 1. 1-39 characters
+    # 2. Only alphanumeric or hyphens
+    # 3. Cannot start or end with hyphen
+    # 4. Cannot have consecutive hyphens
+    pattern = r'^(?!-)(?!.*--)[A-Za-z0-9-]{1,39}(?<!-)$'
+    return bool(re.match(pattern, username))
+
+if __name__ == "__main__":
+    username = input("Enter GitHub username: ")
+    print("Valid" if is_valid_github_username(username) else "Invalid")


### PR DESCRIPTION
## Summary

Added a Python script that validates GitHub usernames using a `re` expression, making sure that usernames are:

- 1 to 39 characters in length
- only alphanumerics and hyphens 
- cannot start or end with hyphens
- cannot have consecutive hyphens