### PR TITLE
Add GitHub username validator script (js)

### DIFF
--- a/javascript/githubUsernameValidator.js
+++ b/javascript/githubUsernameValidator.js
@@ -1,0 +1,5 @@
+function isValidGithubUsername(username) {
+  // 1-39 chars, alphanumeric or hyphen, not start/end with hyphen, no consecutive hyphens
+  const pattern = /^(?!-)(?!.*--)[A-Za-z0-9-]{1,39}(?<!-)$/;
+  return pattern.test(username);
+}


### PR DESCRIPTION
## Summary

Added a Python script that validates GitHub usernames using a `re` expression, making sure that usernames are:

- 1 to 39 characters in length
- only alphanumerics and hyphens 
- cannot start or end with hyphens
- cannot have consecutive hyphens