### PR TITLE
Longest Palindromic Subseuence.java

### DIFF
--- a/java/Longest Palindromic Subseuence.java
+++ b/java/Longest Palindromic Subseuence.java
@@ -1,0 +1,19 @@
+class Solution {
+    public int longestPalindromeSubseq(String s) {
+        int n = s.length();
+        String s2 = new StringBuilder(s).reverse().toString();
+        int[] prev = new int[n + 1];
+        int[] curr = new int[n + 1];
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j <= n; j++) {
+                if (s.charAt(i - 1) == s2.charAt(j - 1)) {
+                    curr[j] = 1 + prev[j - 1];
+                } else {
+                    curr[j] = Math.max(prev[j], curr[j - 1]);
+                }
+            }
+            prev = curr.clone(); 
+        }
+        return prev[n];
+    }
+}


### PR DESCRIPTION
**Approach**
Reverse the original string s to get s2.
Compute the Longest Common Subsequence (LCS) between s and s2.
Use a space-optimized dynamic programming scheme: maintain two arrays prev and curr of length n+1.
prev[j] holds the LCS length for s[0..i-2] vs s2[0..j-1]
curr[j] will hold the LCS length for s[0..i-1] vs s2[0..j-1]
If characters match (s[i-1] == s2[j-1]), set curr[j] = prev[j-1] + 1; else take max(prev[j], curr[j-1]).
After processing each i, copy (or swap) curr into prev for the next iteration.
Return prev[n], which is LCS(s, s2). This equals the length of the longest palindromic subsequence.

**Intuition**
A palindromic subsequence reads the same forward and backward. That means if a sequence p is a subsequence of s and p is a palindrome, then p is also a subsequence of the reverse of s.
Therefore, the longest palindromic subsequence in s must also be a common subsequence between s and its reverse. Hence, LPS(s) = LCS(s, reverse(s)).
The DP transitions for LCS capture the choice: either match characters (if they’re equal) and gain +1, or skip one character from either string (taking the maximum).
Space optimization (using only two rows) works because each row depends only on the previous row and the current row’s left element.